### PR TITLE
feat: Qwen2.5-Omni trimodal embedding (LCO-Embedding)

### DIFF
--- a/.github/workflows/fork-sync.yml
+++ b/.github/workflows/fork-sync.yml
@@ -1,0 +1,22 @@
+name: Fork Sync
+
+on:
+  schedule:
+    - cron: '30 5 * * *'
+  workflow_dispatch:
+    inputs:
+      skip_rebase:
+        description: 'Only sync main, skip rebase of ht'
+        type: boolean
+        default: false
+
+jobs:
+  sync:
+    uses: heiervang-technologies/.github/.github/workflows/fork-sync-reusable.yml@main
+    with:
+      upstream_repo: 'vllm-project/vllm'
+      upstream_branch: 'main'
+      fork_branch: 'ht'
+      skip_rebase: ${{ inputs.skip_rebase || false }}
+    secrets:
+      gh_pat: ${{ secrets.HAI_GH_PAT }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
   push:
-    branches: [main]
+    branches: [main, ht]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,12 +97,12 @@ if(DEFINED CMAKE_CUDA_COMPILER_VERSION AND
    # starting from CUDA 12.9 and Blackwell (10.0), we use family-specific targets (10.0f, 12.0f, etc)
    # to support the whole generation without specifying all sub-architectures
    # see: https://developer.nvidia.com/blog/nvidia-blackwell-and-nvidia-cuda-12-9-introduce-family-specific-architecture-features/
-  set(CUDA_SUPPORTED_ARCHS "7.5;8.0;8.6;8.7;8.9;9.0;10.0;11.0;12.0")
+  set(CUDA_SUPPORTED_ARCHS "6.0;6.1;7.5;8.0;8.6;8.7;8.9;9.0;10.0;11.0;12.0")
 elseif(DEFINED CMAKE_CUDA_COMPILER_VERSION AND
    CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.8)
-  set(CUDA_SUPPORTED_ARCHS "7.5;8.0;8.6;8.7;8.9;9.0;10.0;10.1;10.3;12.0;12.1")
+  set(CUDA_SUPPORTED_ARCHS "6.0;6.1;7.5;8.0;8.6;8.7;8.9;9.0;10.0;10.1;10.3;12.0;12.1")
 else()
-  set(CUDA_SUPPORTED_ARCHS "7.0;7.5;8.0;8.6;8.7;8.9;9.0")
+  set(CUDA_SUPPORTED_ARCHS "6.0;6.1;7.0;7.5;8.0;8.6;8.7;8.9;9.0")
 endif()
 
 #

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,33 @@
+## HT Fork Management
+
+> This section applies to the **Heiervang Technologies fork** only. For upstream contribution guidelines, see below.
+
+This fork follows the [HT Fork Management Guide](https://github.com/orgs/heiervang-technologies/discussions/3). Key points:
+
+### Branch conventions
+
+- **`main`** — Clean fast-forward mirror of upstream `main`. Never commit directly.
+- **`ht`** — Default branch. All HT-specific changes live here, rebased on top of `main`.
+- **Feature branches** — Create from `ht`, squash-merge back into `ht` via PR.
+
+### Sync workflow
+
+1. Fast-forward `main` to match upstream
+2. Rebase `ht` onto the updated `main`
+3. Force-push `ht` (notify teammates so they can recover local branches)
+
+### Commit standards
+
+- Use conventional commits: `feat(scope):`, `fix(scope):`, `docs:`, etc.
+- One logical change per commit — no merge commits from sync (rebase instead)
+- Linear history on `ht`
+
+### Questions & discussion
+
+For all inquiries about this fork — questions, ideas, bug reports, or feature requests — use the [HT Discussions page](https://github.com/orgs/heiervang-technologies/discussions).
+
+---
+
 # Contributing to vLLM
 
 You may find information about contributing to vLLM on [docs.vllm.ai](https://docs.vllm.ai/en/latest/contributing).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,43 @@
 <!-- markdownlint-disable MD001 MD041 -->
+<h1 align="center">ht-vLLM</h1>
+
+<p align="center">
+    <em>Heiervang Technologies fork of <a href="https://github.com/vllm-project/vllm">vLLM</a></em>
+</p>
+
+<p align="center">
+    <a href="https://github.com/orgs/heiervang-technologies/discussions">HT Discussions</a> |
+    <a href="https://github.com/orgs/heiervang-technologies/discussions/3">Fork Management Guide</a> |
+    <a href="https://github.com/vllm-project/vllm">Upstream Project</a> |
+    <a href="https://docs.vllm.ai"><b>Documentation</b></a> |
+    <a href="https://arxiv.org/abs/2309.06180"><b>Paper</b></a> |
+    <a href="https://discuss.vllm.ai"><b>User Forum</b></a> |
+    <a href="https://slack.vllm.ai"><b>Developer Slack</b></a>
+</p>
+
+---
+
+## HT Fork Changes
+
+This is the **Heiervang Technologies** fork of [vLLM](https://github.com/vllm-project/vllm). The `main` branch is kept as a clean fast-forward mirror of upstream. All HT-specific changes live on the `ht` branch.
+
+### What's different from upstream
+
+| Change | Description | Contributed back? |
+|--------|-------------|:-----------------:|
+| HT fork docs | This section, updated CONTRIBUTING.md with fork management guide | No |
+
+### Branch strategy
+
+- **`main`** — Clean mirror of upstream. Never modified directly.
+- **`ht`** — Default branch. Contains all HT-specific additions rebased on top of `main`.
+
+For questions, feature requests, or bug reports related to this fork, please use the [HT Discussions page](https://github.com/orgs/heiervang-technologies/discussions). For upstream issues, use the [upstream repository](https://github.com/vllm-project/vllm/issues).
+
+See the [HT Fork Management Guide](https://github.com/orgs/heiervang-technologies/discussions/3) for our branch conventions, sync workflow, and contribution process.
+
+---
+
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vllm-project/vllm/main/docs/assets/logos/vllm-logo-text-dark.png">

--- a/README.md
+++ b/README.md
@@ -21,11 +21,13 @@
 
 This is the **Heiervang Technologies** fork of [vLLM](https://github.com/vllm-project/vllm). The `main` branch is kept as a clean fast-forward mirror of upstream. All HT-specific changes live on the `ht` branch.
 
-### What's different from upstream
+### HT features on top of upstream
 
 | Change | Description | Contributed back? |
-|--------|-------------|:-----------------:|
+| --- | --- | :---: |
 | HT fork docs | This section, updated CONTRIBUTING.md with fork management guide | No |
+| Pascal CUDA builds | Build support for NVIDIA Pascal GPUs with compute capability `sm_61` | No |
+| Pascal GPTQ DP4A | Correct INT4 `gptq_gemm` decode kernel using DP4A on `sm_61`; measured 2.32× fp16 for `gate_proj`, 2.02× for `down_proj`, and 43.1 vs 39.1 tok/s end to end | No |
 
 ### Branch strategy
 

--- a/csrc/moe/moe_wna16.cu
+++ b/csrc/moe/moe_wna16.cu
@@ -213,8 +213,17 @@ __global__ void moe_wna16_gemm_kernel(
       if (mul_topk_weight) {
         res[m] *= topk_weights[token_index];
       }
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 700
+      // Pascal (sm_61) has no scalar __half/__nv_bfloat16 atomicAdd (added in
+      // sm_70). The MoE-wna16 kernel is never launched on the Pascal gem fleet
+      // (dense models only), so a non-atomic read-modify-write is enough to make
+      // _moe_C compile and import. Do NOT run MoE-wna16 models on sm_61.
+      output[token_index * size_n + offset_n] = Dtype::float2num(
+          Dtype::num2float(output[token_index * size_n + offset_n]) + res[m]);
+#else
       atomicAdd(&output[token_index * size_n + offset_n],
                 Dtype::float2num(res[m]));
+#endif
     }
 
 #if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ < 800

--- a/csrc/quantization/gptq/q_gemm.cu
+++ b/csrc/quantization/gptq/q_gemm.cu
@@ -53,6 +53,195 @@ __host__ __forceinline__ hipblasStatus_t __compat_hipblasHgemm(
   #define rocblas_hgemm __compat_hipblasHgemm
 #endif
 
+#if !defined(USE_ROCM)
+
+// Pascal has fast INT8 dot products but exceptionally slow native FP16 math.
+// Quantize each 32-value activation block to INT8, then multiply the packed
+// GPTQ weights with __dp4a while applying the original per-group scale/zero.
+// Keeping the activation blocks smaller than the GPTQ groups limits the extra
+// activation quantization error without changing the checkpoint format.
+constexpr int PASCAL_DP4A_ACT_BLOCK = 32;
+constexpr int PASCAL_DP4A_THREADS = 128;
+
+__device__ void quantize_half_to_int8_pascal(const half* __restrict__ a,
+                                             int8_t* __restrict__ q_a,
+                                             float2* __restrict__ q_a_params,
+                                             const int size_k,
+                                             const int act_blocks,
+                                             const int row) {
+  const int lane = threadIdx.x & 31;
+  const int warp = threadIdx.x >> 5;
+
+  for (int act_block = warp; act_block < act_blocks; act_block += 4) {
+    const int offset = act_block * PASCAL_DP4A_ACT_BLOCK;
+    const float value = __half2float(a[row * size_k + offset + lane]);
+    float max_abs = fabsf(value);
+
+  #pragma unroll
+    for (int delta = 16; delta > 0; delta >>= 1) {
+      max_abs = fmaxf(max_abs, __shfl_down_sync(0xffffffff, max_abs, delta));
+    }
+    max_abs = __shfl_sync(0xffffffff, max_abs, 0);
+
+    const float scale = max_abs / 127.0f;
+    const float inv_scale = max_abs > 0.0f ? 127.0f / max_abs : 0.0f;
+    int q = __float2int_rn(value * inv_scale);
+    q = q > 127 ? 127 : (q < -127 ? -127 : q);
+    q_a[offset + lane] = static_cast<int8_t>(q);
+
+    int sum = q;
+  #pragma unroll
+    for (int delta = 16; delta > 0; delta >>= 1) {
+      sum += __shfl_down_sync(0xffffffff, sum, delta);
+    }
+    if (lane == 0) {
+      q_a_params[act_block] = make_float2(scale, static_cast<float>(sum));
+    }
+  }
+}
+
+__global__ void gemm_int8_q4_pascal_dp4a_kernel(
+    const half* __restrict__ a, const uint32_t* __restrict__ b_q_weight,
+    const uint32_t* __restrict__ b_gptq_qzeros,
+    const half* __restrict__ b_gptq_scales, half* __restrict__ c,
+    const int size_n, const int size_k, const int groups,
+    const bool use_v2_format) {
+  const int row = blockIdx.y;
+  const int act_blocks = size_k / PASCAL_DP4A_ACT_BLOCK;
+  extern __shared__ int8_t shared_q_a[];
+  float2* shared_q_a_params = reinterpret_cast<float2*>(shared_q_a + size_k);
+  quantize_half_to_int8_pascal(a, shared_q_a, shared_q_a_params, size_k,
+                               act_blocks, row);
+  __syncthreads();
+
+  const int n = blockIdx.x * blockDim.x + threadIdx.x;
+  if (n >= size_n) return;
+
+  const int group_size = size_k / groups;
+  const int zero_width = size_n / 8;
+  const int zero_shift = (n & 7) * 4;
+  const int* q_a_int = reinterpret_cast<const int*>(shared_q_a);
+  float result = 0.0f;
+
+  for (int act_block = 0; act_block < act_blocks; ++act_block) {
+    const int* a_ptr = q_a_int + act_block * 8;
+    int q_dot = 0;
+
+  #pragma unroll
+    for (int packed = 0; packed < 4; ++packed) {
+      const uint32_t q = b_q_weight[(act_block * 4 + packed) * size_n + n];
+      const uint32_t even = q & 0x0f0f0f0f;
+      const uint32_t odd = (q >> 4) & 0x0f0f0f0f;
+      const int q0123 = __byte_perm(even, odd, 0x5140);
+      const int q4567 = __byte_perm(even, odd, 0x7362);
+      q_dot = __dp4a(q0123, a_ptr[packed * 2], q_dot);
+      q_dot = __dp4a(q4567, a_ptr[packed * 2 + 1], q_dot);
+    }
+
+    const int group = act_block * PASCAL_DP4A_ACT_BLOCK / group_size;
+    const uint32_t packed_zero = b_gptq_qzeros[group * zero_width + n / 8];
+    const int zero =
+        ((packed_zero >> zero_shift) & 0x0f) + (use_v2_format ? 0 : 1);
+    const float2 act_params = shared_q_a_params[act_block];
+    const int corrected_dot = q_dot - zero * __float2int_rn(act_params.y);
+    const float weight_scale = __half2float(b_gptq_scales[group * size_n + n]);
+    result = fmaf(static_cast<float>(corrected_dot),
+                  act_params.x * weight_scale, result);
+  }
+
+  c[row * size_n + n] = __float2half_rn(result);
+}
+
+__global__ void gemm_int8_q4_pascal_dp4a_split_k_kernel(
+    const half* __restrict__ a, const uint32_t* __restrict__ b_q_weight,
+    const uint32_t* __restrict__ b_gptq_qzeros,
+    const half* __restrict__ b_gptq_scales, half* __restrict__ c,
+    const int size_n, const int size_k, const int groups,
+    const bool use_v2_format) {
+  const int row = blockIdx.y;
+  const int act_blocks = size_k / PASCAL_DP4A_ACT_BLOCK;
+  extern __shared__ int8_t shared_q_a[];
+  float2* shared_q_a_params = reinterpret_cast<float2*>(shared_q_a + size_k);
+  float* partials = reinterpret_cast<float*>(shared_q_a_params + act_blocks);
+  quantize_half_to_int8_pascal(a, shared_q_a, shared_q_a_params, size_k,
+                               act_blocks, row);
+  __syncthreads();
+
+  const int lane = threadIdx.x & 31;
+  const int warp = threadIdx.x >> 5;
+  const int n = blockIdx.x * 32 + lane;
+  const int group_size = size_k / groups;
+  const int zero_width = size_n / 8;
+  const int zero_shift = (n & 7) * 4;
+  const int* q_a_int = reinterpret_cast<const int*>(shared_q_a);
+  float result = 0.0f;
+
+  if (n < size_n) {
+    for (int act_block = warp; act_block < act_blocks; act_block += 4) {
+      const int* a_ptr = q_a_int + act_block * 8;
+      int q_dot = 0;
+
+  #pragma unroll
+      for (int packed = 0; packed < 4; ++packed) {
+        const uint32_t q = b_q_weight[(act_block * 4 + packed) * size_n + n];
+        const uint32_t even = q & 0x0f0f0f0f;
+        const uint32_t odd = (q >> 4) & 0x0f0f0f0f;
+        const int q0123 = __byte_perm(even, odd, 0x5140);
+        const int q4567 = __byte_perm(even, odd, 0x7362);
+        q_dot = __dp4a(q0123, a_ptr[packed * 2], q_dot);
+        q_dot = __dp4a(q4567, a_ptr[packed * 2 + 1], q_dot);
+      }
+
+      const int group = act_block * PASCAL_DP4A_ACT_BLOCK / group_size;
+      const uint32_t packed_zero = b_gptq_qzeros[group * zero_width + n / 8];
+      const int zero =
+          ((packed_zero >> zero_shift) & 0x0f) + (use_v2_format ? 0 : 1);
+      const float2 act_params = shared_q_a_params[act_block];
+      const int corrected_dot = q_dot - zero * __float2int_rn(act_params.y);
+      const float weight_scale =
+          __half2float(b_gptq_scales[group * size_n + n]);
+      result = fmaf(static_cast<float>(corrected_dot),
+                    act_params.x * weight_scale, result);
+    }
+  }
+
+  partials[warp * 32 + lane] = result;
+  __syncthreads();
+  if (warp == 0 && n < size_n) {
+    result = partials[lane] + partials[32 + lane] + partials[64 + lane] +
+             partials[96 + lane];
+    c[row * size_n + n] = __float2half_rn(result);
+  }
+}
+
+void gemm_half_q_half_pascal_dp4a(const half* a, const uint32_t* b_q_weight,
+                                  const uint32_t* b_gptq_qzeros,
+                                  const half* b_gptq_scales, half* c,
+                                  int size_m, int size_n, int size_k,
+                                  int groups, bool use_v2_format) {
+  const int act_blocks = size_k / PASCAL_DP4A_ACT_BLOCK;
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  const int activation_shared_bytes =
+      size_k * sizeof(int8_t) + act_blocks * sizeof(float2);
+  if (size_k >= 4096) {
+    dim3 gemm_grid(DIVIDE(size_n, 32), size_m);
+    const int shared_bytes =
+        activation_shared_bytes + PASCAL_DP4A_THREADS * sizeof(float);
+    gemm_int8_q4_pascal_dp4a_split_k_kernel<<<gemm_grid, PASCAL_DP4A_THREADS,
+                                              shared_bytes, stream>>>(
+        a, b_q_weight, b_gptq_qzeros, b_gptq_scales, c, size_n, size_k, groups,
+        use_v2_format);
+  } else {
+    dim3 gemm_grid(DIVIDE(size_n, PASCAL_DP4A_THREADS), size_m);
+    gemm_int8_q4_pascal_dp4a_kernel<<<gemm_grid, PASCAL_DP4A_THREADS,
+                                      activation_shared_bytes, stream>>>(
+        a, b_q_weight, b_gptq_qzeros, b_gptq_scales, c, size_n, size_k, groups,
+        use_v2_format);
+  }
+}
+
+#endif
+
 __forceinline__ __device__ half2 dot22_8(half2 (&dq)[4], const half* a_ptr,
                                          const half2 g_result) {
   half2 result = {};
@@ -1831,7 +2020,39 @@ torch::Tensor gptq_gemm(torch::Tensor a, torch::Tensor b_q_weight,
                         bool use_exllama, bool use_v2_format, int64_t bit) {
   const at::cuda::OptionalCUDAGuard device_guard(device_of(a));
   auto options = torch::TensorOptions().dtype(a.dtype()).device(a.device());
-  at::Tensor c = torch::zeros({a.size(0), b_q_weight.size(1)}, options);
+
+  bool use_pascal_dp4a = false;
+#if !defined(USE_ROCM)
+  const auto* device_properties = at::cuda::getCurrentDeviceProperties();
+  const int64_t size_k = a.size(1);
+  const int64_t groups = b_gptq_qzeros.size(0);
+  use_pascal_dp4a =
+      device_properties->major == 6 && device_properties->minor == 1 &&
+      bit == 4 && !use_exllama && b_g_idx.numel() == 0 &&
+      a.size(0) <= MAX_ALT_GEMM_ROWS && groups > 0 && size_k % groups == 0 &&
+      size_k % vllm::gptq::PASCAL_DP4A_ACT_BLOCK == 0 &&
+      (size_k / groups) % vllm::gptq::PASCAL_DP4A_ACT_BLOCK == 0 &&
+      size_k + size_k / vllm::gptq::PASCAL_DP4A_ACT_BLOCK * sizeof(float2) <=
+          device_properties->sharedMemPerBlock -
+              (size_k >= 4096 ? vllm::gptq::PASCAL_DP4A_THREADS * sizeof(float)
+                              : 0);
+#endif
+
+  at::Tensor c = use_pascal_dp4a
+                     ? torch::empty({a.size(0), b_q_weight.size(1)}, options)
+                     : torch::zeros({a.size(0), b_q_weight.size(1)}, options);
+
+#if !defined(USE_ROCM)
+  if (use_pascal_dp4a) {
+    vllm::gptq::gemm_half_q_half_pascal_dp4a(
+        (const half*)a.data_ptr(), (const uint32_t*)b_q_weight.data_ptr(),
+        (const uint32_t*)b_gptq_qzeros.data_ptr(),
+        (const half*)b_gptq_scales.data_ptr(), (half*)c.data_ptr(), c.size(0),
+        c.size(1), a.size(1), b_gptq_qzeros.size(0), use_v2_format);
+    return c;
+  }
+#endif
+
   at::Tensor temp_dq = torch::empty(
       {b_q_weight.size(0) * 32 / bit, b_q_weight.size(1)}, options);
 

--- a/tests/kernels/quantization/test_gptq.py
+++ b/tests/kernels/quantization/test_gptq.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import pytest
 import torch
 
 from tests.kernels.utils import opcheck
@@ -33,3 +34,49 @@ def test_gptq_gemm_opcheck():
     opcheck(
         torch.ops._C.gptq_gemm, (a, weight, zeros, scales, idx, use_exllama, False, bit)
     )
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() != (6, 1),
+    reason="Pascal DP4A kernel requires compute capability 6.1",
+)
+@pytest.mark.parametrize("use_v2_format", [False, True])
+@pytest.mark.parametrize("size_k,group_size,atol", [(256, 64, 0.03), (4096, 128, 0.12)])
+def test_gptq_gemm_pascal_dp4a_numerics(
+    use_v2_format: bool, size_k: int, group_size: int, atol: float
+):
+    torch.manual_seed(0)
+    size_n = 256
+    groups = size_k // group_size
+
+    q_values = torch.randint(0, 16, (size_k, size_n), device="cuda", dtype=torch.int64)
+    shifts = torch.arange(0, 32, 4, device="cuda", dtype=torch.int64)
+    qweight = (
+        (q_values.reshape(size_k // 8, 8, size_n) << shifts[None, :, None])
+        .sum(dim=1)
+        .to(torch.int32)
+    )
+
+    zero_points = torch.randint(
+        1, 16, (groups, size_n), device="cuda", dtype=torch.int64
+    )
+    stored_zeros = zero_points if use_v2_format else zero_points - 1
+    qzeros = (
+        (stored_zeros.reshape(groups, size_n // 8, 8) << shifts[None, None, :])
+        .sum(dim=-1)
+        .to(torch.int32)
+    )
+    scales = (
+        torch.rand((groups, size_n), device="cuda", dtype=torch.float16) * 0.04 + 0.01
+    )
+    a = torch.randn((1, size_k), device="cuda", dtype=torch.float16) * 0.5
+    empty_idx = torch.empty((0,), device="cuda", dtype=torch.int32)
+
+    output = torch.ops._C.gptq_gemm(
+        a, qweight, qzeros, scales, empty_idx, False, use_v2_format, 4
+    )
+    weight = (q_values - zero_points.repeat_interleave(group_size, dim=0)).float()
+    weight *= scales.repeat_interleave(group_size, dim=0).float()
+    reference = a.float() @ weight
+
+    torch.testing.assert_close(output.float(), reference, rtol=0.03, atol=atol)

--- a/vllm/model_executor/layers/quantization/gptq.py
+++ b/vllm/model_executor/layers/quantization/gptq.py
@@ -29,6 +29,7 @@ from vllm.model_executor.parameter import (
     PackedvLLMParameter,
     RowvLLMParameter,
 )
+from vllm.platforms import current_platform
 from vllm.transformers_utils.config import get_safetensors_params_metadata
 from vllm.utils.collection_utils import is_list_of
 
@@ -39,6 +40,8 @@ else:
     QuantizationMethods = str
 
 logger = init_logger(__name__)
+
+PASCAL_DP4A_MAX_ROWS = 8
 
 
 class GPTQConfig(QuantizationConfig):
@@ -94,9 +97,16 @@ class GPTQConfig(QuantizationConfig):
                 "Currently, only 2/3/4/8-bit weight quantization is "
                 f"supported for GPTQ, but got {self.weight_bits} bits."
             )
-        # Somehow gptq_gemm 4-bit is buggy, maybe fix it in the future.
-        # For now, show a warning, since gptq_marlin will be used by default.
-        if self.weight_bits == 4:
+        # Pascal uses a dedicated DP4A kernel for sequential 4-bit weights.
+        # Other gptq_gemm configurations retain the existing warning since
+        # gptq_marlin remains the preferred CUDA path where it is available.
+        pascal_dp4a = (
+            self.weight_bits == 4
+            and not self.desc_act
+            and (self.group_size == -1 or self.group_size % 32 == 0)
+            and current_platform.is_device_capability(61)
+        )
+        if self.weight_bits == 4 and not pascal_dp4a:
             logger.warning_once(
                 "Currently, the 4-bit gptq_gemm kernel for GPTQ is buggy. "
                 "Please switch to gptq_marlin."
@@ -238,6 +248,13 @@ class GPTQLinearMethod(LinearMethodBase):
     def __init__(self, quant_config: GPTQConfig):
         self.quant_config = quant_config
 
+        self.use_pascal_dp4a = (
+            quant_config.weight_bits == 4
+            and not quant_config.desc_act
+            and (quant_config.group_size == -1 or quant_config.group_size % 32 == 0)
+            and current_platform.is_device_capability(61)
+        )
+
         # GPTQ v1 and v2 format deals with zero points differently
         self.use_v2_format = quant_config.checkpoint_format == "gptq_v2"
 
@@ -271,7 +288,17 @@ class GPTQLinearMethod(LinearMethodBase):
             group_size = self.quant_config.group_size
         else:
             group_size = input_size
-        exllama_state = ExllamaState.UNINITIALIZED
+        layer.pascal_dp4a_enabled = (
+            self.use_pascal_dp4a
+            and input_size == input_size_per_partition
+            and input_size_per_partition % 32 == 0
+            and group_size % 32 == 0
+        )
+        exllama_state = (
+            ExllamaState.UNUSED
+            if layer.pascal_dp4a_enabled
+            else ExllamaState.UNINITIALIZED
+        )
         scale_and_zero_size = input_size // group_size
         scale_and_zero_input_dim = None
         if (
@@ -302,7 +329,12 @@ class GPTQLinearMethod(LinearMethodBase):
         g_idx = RowvLLMParameter(
             data=torch.tensor(
                 [
-                    i // self.quant_config.group_size
+                    i
+                    // (
+                        group_size
+                        if layer.pascal_dp4a_enabled
+                        else self.quant_config.group_size
+                    )
                     for i in range(input_size_per_partition)
                 ],
                 dtype=torch.int32,
@@ -361,6 +393,16 @@ class GPTQLinearMethod(LinearMethodBase):
         layer.g_idx = Parameter(layer.g_idx.data, requires_grad=False)
         layer.scales = Parameter(layer.scales.data, requires_grad=False)
 
+        if layer.pascal_dp4a_enabled:
+            # Preserve the sequential g_idx for large-prefill reconstruction.
+            # An empty tensor selects DP4A only for the small-row decode path.
+            layer.register_buffer(
+                "pascal_dp4a_idx",
+                torch.empty((0,), dtype=torch.int, device=layer.g_idx.device),
+                persistent=False,
+            )
+            return
+
         # exllama needs to shuffle the weight after the weight is loaded
         # here we do the shuffle on first forward pass
         if layer.exllama_state == ExllamaState.UNINITIALIZED:
@@ -384,12 +426,17 @@ class GPTQLinearMethod(LinearMethodBase):
 
         # GPTQ v1 and v2 format checkpoints deals with zero points differently,
         # and require different gemm kernels.
+        g_idx = (
+            layer.pascal_dp4a_idx
+            if layer.pascal_dp4a_enabled and reshaped_x.shape[0] <= PASCAL_DP4A_MAX_ROWS
+            else layer.g_idx
+        )
         output = ops.gptq_gemm(
             reshaped_x,
             layer.qweight,
             layer.qzeros,
             layer.scales,
-            layer.g_idx,
+            g_idx,
             layer.exllama_state == ExllamaState.READY,
             self.use_v2_format,
             self.quant_config.weight_bits,

--- a/vllm/model_executor/models/qwen2_5_omni_embed.py
+++ b/vllm/model_executor/models/qwen2_5_omni_embed.py
@@ -11,7 +11,7 @@ Target models:
 - LCO-Embedding/LCO-Embedding-Omni-7B
 """
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable
 
 import torch
 

--- a/vllm/model_executor/models/qwen2_5_omni_embed.py
+++ b/vllm/model_executor/models/qwen2_5_omni_embed.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Qwen2.5-Omni Thinker embedding model for trimodal embeddings.
+
+Extends the Qwen2.5-Omni thinker (generation model) with pooling support
+for text/image/audio → embedding tasks. Uses LAST token pooling
+with L2 normalization.
+
+Target models:
+- LCO-Embedding/LCO-Embedding-Omni-7B
+"""
+
+from collections.abc import Iterable, Mapping
+
+import torch
+
+from vllm.config import VllmConfig
+from vllm.model_executor.layers.pooler.seqwise import pooler_for_embed
+from vllm.multimodal import MULTIMODAL_REGISTRY
+
+from .interfaces_base import default_pooling_type
+from .qwen2_5_omni_thinker import (
+    Qwen2_5OmniThinkerDummyInputsBuilder,
+    Qwen2_5OmniThinkerForConditionalGeneration,
+    Qwen2_5OmniThinkerMultiModalProcessor,
+    Qwen2_5OmniThinkerProcessingInfo,
+)
+from .utils import AutoWeightsLoader, WeightsMapper
+
+
+class Qwen2_5OmniEmbeddingProcessingInfo(Qwen2_5OmniThinkerProcessingInfo):
+    """Processing info that handles standalone thinker configs.
+
+    LCO-Embedding models ship the thinker config directly as config.json
+    (model_type: qwen2_5_omni_thinker) rather than wrapping it inside a
+    parent Qwen2_5OmniConfig with a .thinker_config attribute. This
+    subclass handles both layouts transparently.
+    """
+
+    def get_hf_config(self):
+        hf_config = self.ctx.get_hf_config()
+        if hasattr(hf_config, "thinker_config"):
+            return hf_config.thinker_config
+        return hf_config
+
+
+@default_pooling_type(seq_pooling_type="LAST")
+@MULTIMODAL_REGISTRY.register_processor(
+    Qwen2_5OmniThinkerMultiModalProcessor,
+    info=Qwen2_5OmniEmbeddingProcessingInfo,
+    dummy_inputs=Qwen2_5OmniThinkerDummyInputsBuilder,
+)
+class Qwen2_5OmniEmbeddingModel(Qwen2_5OmniThinkerForConditionalGeneration):
+    """Qwen2.5-Omni thinker adapted for embedding inference.
+
+    Adds sequence-level pooling (LAST token + L2 normalize) on top of
+    the generation model's hidden states. Supports text, image, audio,
+    and video inputs — any modality the thinker backbone accepts.
+
+    The forward pass is inherited from the generation model: it returns
+    hidden_states from the language model's transformer layers. The
+    pooler then extracts the last-token embedding and L2-normalizes it.
+    """
+
+    is_pooling_model = True
+
+    # Weight mapper for standalone thinker models (no "thinker." prefix).
+    # More-specific prefixes must come first because WeightsMapper applies
+    # ALL matching prefix rules sequentially.
+    hf_to_vllm_mapper = WeightsMapper(
+        orig_to_new_prefix={
+            # Full Omni model weights (with thinker. prefix)
+            "thinker.lm_head.": "language_model.lm_head.",
+            "thinker.model.": "language_model.model.",
+            "thinker.": "",
+            # Standalone thinker weights (no thinker. prefix)
+            "lm_head.": "language_model.lm_head.",
+            "model.": "language_model.model.",
+        }
+    )
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        hf_config = vllm_config.model_config.hf_config
+
+        # Standalone thinker configs (e.g. LCO-Embedding) lack
+        # .thinker_config — add a self-reference so the parent __init__
+        # can access it uniformly.
+        if not hasattr(hf_config, "thinker_config"):
+            hf_config.thinker_config = hf_config
+
+        super().__init__(vllm_config=vllm_config, prefix=prefix)
+
+        pooler_config = vllm_config.model_config.pooler_config
+        assert pooler_config is not None
+        self.pooler = pooler_for_embed(pooler_config)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(self, skip_prefixes=["talker.", "token2wav."])
+        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -263,6 +263,14 @@ _EMBEDDING_MODELS = {
     ),
     "Phi3VForCausalLM": ("phi3v", "Phi3VForCausalLM"),
     "Qwen2VLForConditionalGeneration": ("qwen2_vl", "Qwen2VLForConditionalGeneration"),
+    "Qwen2_5OmniThinkerForConditionalGeneration": (  # LCO-Embedding-Omni-7B
+        "qwen2_5_omni_embed",
+        "Qwen2_5OmniEmbeddingModel",
+    ),
+    "Qwen2_5OmniModel": (  # Full Qwen2.5-Omni used for embedding
+        "qwen2_5_omni_embed",
+        "Qwen2_5OmniEmbeddingModel",
+    ),
     "SiglipModel": ("siglip", "SiglipEmbeddingModel"),
     # Technically Terratorch models work on images, both in
     # input and output. I am adding it here because it piggy-backs on embedding


### PR DESCRIPTION
## Summary
- Add embedding inference support for Qwen2.5-Omni thinker models (text/image/audio → vector)
- New model file `qwen2_5_omni_embed.py` extending the generation model with LAST token pooling + L2 normalization
- Handles both standalone thinker configs (LCO-Embedding-Omni-7B) and full Qwen2.5-Omni configs
- Registered in `_EMBEDDING_MODELS` for `Qwen2_5OmniThinkerForConditionalGeneration` and `Qwen2_5OmniModel` architectures

## Usage
```bash
vllm serve LCO-Embedding/LCO-Embedding-Omni-7B --task embed
```

## Test plan
- [ ] Load LCO-Embedding-Omni-7B with `--task embed` and verify model starts
- [ ] Send text embedding request and verify 3584-dim L2-normalized output
- [ ] Send image embedding request and verify cross-modal embedding
- [ ] Send audio embedding request and verify trimodal support
- [ ] Compare embeddings against HuggingFace reference implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)