### PR TITLE
feat(build): Pascal (sm_61) support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,12 +97,12 @@ if(DEFINED CMAKE_CUDA_COMPILER_VERSION AND
    # starting from CUDA 12.9 and Blackwell (10.0), we use family-specific targets (10.0f, 12.0f, etc)
    # to support the whole generation without specifying all sub-architectures
    # see: https://developer.nvidia.com/blog/nvidia-blackwell-and-nvidia-cuda-12-9-introduce-family-specific-architecture-features/
-  set(CUDA_SUPPORTED_ARCHS "7.5;8.0;8.6;8.7;8.9;9.0;10.0;11.0;12.0")
+  set(CUDA_SUPPORTED_ARCHS "6.0;6.1;7.5;8.0;8.6;8.7;8.9;9.0;10.0;11.0;12.0")
 elseif(DEFINED CMAKE_CUDA_COMPILER_VERSION AND
    CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.8)
-  set(CUDA_SUPPORTED_ARCHS "7.5;8.0;8.6;8.7;8.9;9.0;10.0;10.1;10.3;12.0;12.1")
+  set(CUDA_SUPPORTED_ARCHS "6.0;6.1;7.5;8.0;8.6;8.7;8.9;9.0;10.0;10.1;10.3;12.0;12.1")
 else()
-  set(CUDA_SUPPORTED_ARCHS "7.0;7.5;8.0;8.6;8.7;8.9;9.0")
+  set(CUDA_SUPPORTED_ARCHS "6.0;6.1;7.0;7.5;8.0;8.6;8.7;8.9;9.0")
 endif()
 
 #

--- a/csrc/moe/moe_wna16.cu
+++ b/csrc/moe/moe_wna16.cu
@@ -213,8 +213,17 @@ __global__ void moe_wna16_gemm_kernel(
       if (mul_topk_weight) {
         res[m] *= topk_weights[token_index];
       }
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 700
+      // Pascal (sm_61) has no scalar __half/__nv_bfloat16 atomicAdd (added in
+      // sm_70). The MoE-wna16 kernel is never launched on the Pascal gem fleet
+      // (dense models only), so a non-atomic read-modify-write is enough to make
+      // _moe_C compile and import. Do NOT run MoE-wna16 models on sm_61.
+      output[token_index * size_n + offset_n] = Dtype::float2num(
+          Dtype::num2float(output[token_index * size_n + offset_n]) + res[m]);
+#else
       atomicAdd(&output[token_index * size_n + offset_n],
                 Dtype::float2num(res[m]));
+#endif
     }
 
 #if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ < 800


### PR DESCRIPTION
## What

Make the vLLM CUDA extension build for **Pascal (sm_61)** — Quadro P5200 / GTX 10-series — so the fork supports the Pascal gem fleet natively, instead of applying this as an out-of-tree patch at image-build time.

Two changes:

1. **`CMakeLists.txt`** — prepend `6.0;6.1` to `CUDA_SUPPORTED_ARCHS` in all three CUDA-version branches, so the build emits Pascal cubins (cu126 is the last lane that still ships Pascal SASS).
2. **`csrc/moe/moe_wna16.cu`** — non-atomic fallback for the output accumulation when `__CUDA_ARCH__ < 700`. Pascal has no scalar `__half`/`__nv_bfloat16` `atomicAdd` (added in sm_70), which otherwise fails to compile. MoE-wna16 is **never launched on the Pascal gems** (dense models only), so the fallback only needs to compile and import — **do not run MoE-wna16 models on sm_61.**

## Why

The Pascal gem fleet (and repurposed gems like emerald, now a personal box) runs core vLLM models — e.g. Qwen3-ASR speech-to-text for `ears`. Upstream drops Pascal from `CUDA_SUPPORTED_ARCHS`, so the stock wheel won't load. This is the minimal enablement to build for sm_61.

## Verified

Build-verified end-to-end: vLLM **v0.20.0** + this change compiles for `TORCH_CUDA_ARCH_LIST=6.1` on the cu126 lane and **serves `Qwen/Qwen3-ASR-1.7B` on a Quadro P5200 (sm_61)** — real transcriptions, fp16, TRITON_ATTN, CUDA-graph decode. The container recipe that consumes this lives in `hai-os` (`containers/vllm-pascal/`).

## Scope / caveats

- fp16 only on Pascal (no bf16 hardware).
- Attention: `TRITON_ATTN` is the only viable sm_61 backend (FA2/FA3 gate to sm_80/sm_90).
- Heavier quantized MoE kernels are compile-only on sm_61, not runnable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)