### PR TITLE
feat(gptq): add Pascal DP4A decode kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,13 @@
 
 This is the **Heiervang Technologies** fork of [vLLM](https://github.com/vllm-project/vllm). The `main` branch is kept as a clean fast-forward mirror of upstream. All HT-specific changes live on the `ht` branch.
 
-### What's different from upstream
+### HT features on top of upstream
 
 | Change | Description | Contributed back? |
-|--------|-------------|:-----------------:|
+| --- | --- | :---: |
 | HT fork docs | This section, updated CONTRIBUTING.md with fork management guide | No |
+| Pascal CUDA builds | Build support for NVIDIA Pascal GPUs with compute capability `sm_61` | No |
+| Pascal GPTQ DP4A | Correct INT4 `gptq_gemm` decode kernel using DP4A on `sm_61`; measured 2.32× fp16 for `gate_proj`, 2.02× for `down_proj`, and 43.1 vs 39.1 tok/s end to end | No |
 
 ### Branch strategy
 

--- a/csrc/quantization/gptq/q_gemm.cu
+++ b/csrc/quantization/gptq/q_gemm.cu
@@ -53,6 +53,195 @@ __host__ __forceinline__ hipblasStatus_t __compat_hipblasHgemm(
   #define rocblas_hgemm __compat_hipblasHgemm
 #endif
 
+#if !defined(USE_ROCM)
+
+// Pascal has fast INT8 dot products but exceptionally slow native FP16 math.
+// Quantize each 32-value activation block to INT8, then multiply the packed
+// GPTQ weights with __dp4a while applying the original per-group scale/zero.
+// Keeping the activation blocks smaller than the GPTQ groups limits the extra
+// activation quantization error without changing the checkpoint format.
+constexpr int PASCAL_DP4A_ACT_BLOCK = 32;
+constexpr int PASCAL_DP4A_THREADS = 128;
+
+__device__ void quantize_half_to_int8_pascal(const half* __restrict__ a,
+                                             int8_t* __restrict__ q_a,
+                                             float2* __restrict__ q_a_params,
+                                             const int size_k,
+                                             const int act_blocks,
+                                             const int row) {
+  const int lane = threadIdx.x & 31;
+  const int warp = threadIdx.x >> 5;
+
+  for (int act_block = warp; act_block < act_blocks; act_block += 4) {
+    const int offset = act_block * PASCAL_DP4A_ACT_BLOCK;
+    const float value = __half2float(a[row * size_k + offset + lane]);
+    float max_abs = fabsf(value);
+
+  #pragma unroll
+    for (int delta = 16; delta > 0; delta >>= 1) {
+      max_abs = fmaxf(max_abs, __shfl_down_sync(0xffffffff, max_abs, delta));
+    }
+    max_abs = __shfl_sync(0xffffffff, max_abs, 0);
+
+    const float scale = max_abs / 127.0f;
+    const float inv_scale = max_abs > 0.0f ? 127.0f / max_abs : 0.0f;
+    int q = __float2int_rn(value * inv_scale);
+    q = q > 127 ? 127 : (q < -127 ? -127 : q);
+    q_a[offset + lane] = static_cast<int8_t>(q);
+
+    int sum = q;
+  #pragma unroll
+    for (int delta = 16; delta > 0; delta >>= 1) {
+      sum += __shfl_down_sync(0xffffffff, sum, delta);
+    }
+    if (lane == 0) {
+      q_a_params[act_block] = make_float2(scale, static_cast<float>(sum));
+    }
+  }
+}
+
+__global__ void gemm_int8_q4_pascal_dp4a_kernel(
+    const half* __restrict__ a, const uint32_t* __restrict__ b_q_weight,
+    const uint32_t* __restrict__ b_gptq_qzeros,
+    const half* __restrict__ b_gptq_scales, half* __restrict__ c,
+    const int size_n, const int size_k, const int groups,
+    const bool use_v2_format) {
+  const int row = blockIdx.y;
+  const int act_blocks = size_k / PASCAL_DP4A_ACT_BLOCK;
+  extern __shared__ int8_t shared_q_a[];
+  float2* shared_q_a_params = reinterpret_cast<float2*>(shared_q_a + size_k);
+  quantize_half_to_int8_pascal(a, shared_q_a, shared_q_a_params, size_k,
+                               act_blocks, row);
+  __syncthreads();
+
+  const int n = blockIdx.x * blockDim.x + threadIdx.x;
+  if (n >= size_n) return;
+
+  const int group_size = size_k / groups;
+  const int zero_width = size_n / 8;
+  const int zero_shift = (n & 7) * 4;
+  const int* q_a_int = reinterpret_cast<const int*>(shared_q_a);
+  float result = 0.0f;
+
+  for (int act_block = 0; act_block < act_blocks; ++act_block) {
+    const int* a_ptr = q_a_int + act_block * 8;
+    int q_dot = 0;
+
+  #pragma unroll
+    for (int packed = 0; packed < 4; ++packed) {
+      const uint32_t q = b_q_weight[(act_block * 4 + packed) * size_n + n];
+      const uint32_t even = q & 0x0f0f0f0f;
+      const uint32_t odd = (q >> 4) & 0x0f0f0f0f;
+      const int q0123 = __byte_perm(even, odd, 0x5140);
+      const int q4567 = __byte_perm(even, odd, 0x7362);
+      q_dot = __dp4a(q0123, a_ptr[packed * 2], q_dot);
+      q_dot = __dp4a(q4567, a_ptr[packed * 2 + 1], q_dot);
+    }
+
+    const int group = act_block * PASCAL_DP4A_ACT_BLOCK / group_size;
+    const uint32_t packed_zero = b_gptq_qzeros[group * zero_width + n / 8];
+    const int zero =
+        ((packed_zero >> zero_shift) & 0x0f) + (use_v2_format ? 0 : 1);
+    const float2 act_params = shared_q_a_params[act_block];
+    const int corrected_dot = q_dot - zero * __float2int_rn(act_params.y);
+    const float weight_scale = __half2float(b_gptq_scales[group * size_n + n]);
+    result = fmaf(static_cast<float>(corrected_dot),
+                  act_params.x * weight_scale, result);
+  }
+
+  c[row * size_n + n] = __float2half_rn(result);
+}
+
+__global__ void gemm_int8_q4_pascal_dp4a_split_k_kernel(
+    const half* __restrict__ a, const uint32_t* __restrict__ b_q_weight,
+    const uint32_t* __restrict__ b_gptq_qzeros,
+    const half* __restrict__ b_gptq_scales, half* __restrict__ c,
+    const int size_n, const int size_k, const int groups,
+    const bool use_v2_format) {
+  const int row = blockIdx.y;
+  const int act_blocks = size_k / PASCAL_DP4A_ACT_BLOCK;
+  extern __shared__ int8_t shared_q_a[];
+  float2* shared_q_a_params = reinterpret_cast<float2*>(shared_q_a + size_k);
+  float* partials = reinterpret_cast<float*>(shared_q_a_params + act_blocks);
+  quantize_half_to_int8_pascal(a, shared_q_a, shared_q_a_params, size_k,
+                               act_blocks, row);
+  __syncthreads();
+
+  const int lane = threadIdx.x & 31;
+  const int warp = threadIdx.x >> 5;
+  const int n = blockIdx.x * 32 + lane;
+  const int group_size = size_k / groups;
+  const int zero_width = size_n / 8;
+  const int zero_shift = (n & 7) * 4;
+  const int* q_a_int = reinterpret_cast<const int*>(shared_q_a);
+  float result = 0.0f;
+
+  if (n < size_n) {
+    for (int act_block = warp; act_block < act_blocks; act_block += 4) {
+      const int* a_ptr = q_a_int + act_block * 8;
+      int q_dot = 0;
+
+  #pragma unroll
+      for (int packed = 0; packed < 4; ++packed) {
+        const uint32_t q = b_q_weight[(act_block * 4 + packed) * size_n + n];
+        const uint32_t even = q & 0x0f0f0f0f;
+        const uint32_t odd = (q >> 4) & 0x0f0f0f0f;
+        const int q0123 = __byte_perm(even, odd, 0x5140);
+        const int q4567 = __byte_perm(even, odd, 0x7362);
+        q_dot = __dp4a(q0123, a_ptr[packed * 2], q_dot);
+        q_dot = __dp4a(q4567, a_ptr[packed * 2 + 1], q_dot);
+      }
+
+      const int group = act_block * PASCAL_DP4A_ACT_BLOCK / group_size;
+      const uint32_t packed_zero = b_gptq_qzeros[group * zero_width + n / 8];
+      const int zero =
+          ((packed_zero >> zero_shift) & 0x0f) + (use_v2_format ? 0 : 1);
+      const float2 act_params = shared_q_a_params[act_block];
+      const int corrected_dot = q_dot - zero * __float2int_rn(act_params.y);
+      const float weight_scale =
+          __half2float(b_gptq_scales[group * size_n + n]);
+      result = fmaf(static_cast<float>(corrected_dot),
+                    act_params.x * weight_scale, result);
+    }
+  }
+
+  partials[warp * 32 + lane] = result;
+  __syncthreads();
+  if (warp == 0 && n < size_n) {
+    result = partials[lane] + partials[32 + lane] + partials[64 + lane] +
+             partials[96 + lane];
+    c[row * size_n + n] = __float2half_rn(result);
+  }
+}
+
+void gemm_half_q_half_pascal_dp4a(const half* a, const uint32_t* b_q_weight,
+                                  const uint32_t* b_gptq_qzeros,
+                                  const half* b_gptq_scales, half* c,
+                                  int size_m, int size_n, int size_k,
+                                  int groups, bool use_v2_format) {
+  const int act_blocks = size_k / PASCAL_DP4A_ACT_BLOCK;
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  const int activation_shared_bytes =
+      size_k * sizeof(int8_t) + act_blocks * sizeof(float2);
+  if (size_k >= 4096) {
+    dim3 gemm_grid(DIVIDE(size_n, 32), size_m);
+    const int shared_bytes =
+        activation_shared_bytes + PASCAL_DP4A_THREADS * sizeof(float);
+    gemm_int8_q4_pascal_dp4a_split_k_kernel<<<gemm_grid, PASCAL_DP4A_THREADS,
+                                              shared_bytes, stream>>>(
+        a, b_q_weight, b_gptq_qzeros, b_gptq_scales, c, size_n, size_k, groups,
+        use_v2_format);
+  } else {
+    dim3 gemm_grid(DIVIDE(size_n, PASCAL_DP4A_THREADS), size_m);
+    gemm_int8_q4_pascal_dp4a_kernel<<<gemm_grid, PASCAL_DP4A_THREADS,
+                                      activation_shared_bytes, stream>>>(
+        a, b_q_weight, b_gptq_qzeros, b_gptq_scales, c, size_n, size_k, groups,
+        use_v2_format);
+  }
+}
+
+#endif
+
 __forceinline__ __device__ half2 dot22_8(half2 (&dq)[4], const half* a_ptr,
                                          const half2 g_result) {
   half2 result = {};
@@ -1831,7 +2020,39 @@ torch::Tensor gptq_gemm(torch::Tensor a, torch::Tensor b_q_weight,
                         bool use_exllama, bool use_v2_format, int64_t bit) {
   const at::cuda::OptionalCUDAGuard device_guard(device_of(a));
   auto options = torch::TensorOptions().dtype(a.dtype()).device(a.device());
-  at::Tensor c = torch::zeros({a.size(0), b_q_weight.size(1)}, options);
+
+  bool use_pascal_dp4a = false;
+#if !defined(USE_ROCM)
+  const auto* device_properties = at::cuda::getCurrentDeviceProperties();
+  const int64_t size_k = a.size(1);
+  const int64_t groups = b_gptq_qzeros.size(0);
+  use_pascal_dp4a =
+      device_properties->major == 6 && device_properties->minor == 1 &&
+      bit == 4 && !use_exllama && b_g_idx.numel() == 0 &&
+      a.size(0) <= MAX_ALT_GEMM_ROWS && groups > 0 && size_k % groups == 0 &&
+      size_k % vllm::gptq::PASCAL_DP4A_ACT_BLOCK == 0 &&
+      (size_k / groups) % vllm::gptq::PASCAL_DP4A_ACT_BLOCK == 0 &&
+      size_k + size_k / vllm::gptq::PASCAL_DP4A_ACT_BLOCK * sizeof(float2) <=
+          device_properties->sharedMemPerBlock -
+              (size_k >= 4096 ? vllm::gptq::PASCAL_DP4A_THREADS * sizeof(float)
+                              : 0);
+#endif
+
+  at::Tensor c = use_pascal_dp4a
+                     ? torch::empty({a.size(0), b_q_weight.size(1)}, options)
+                     : torch::zeros({a.size(0), b_q_weight.size(1)}, options);
+
+#if !defined(USE_ROCM)
+  if (use_pascal_dp4a) {
+    vllm::gptq::gemm_half_q_half_pascal_dp4a(
+        (const half*)a.data_ptr(), (const uint32_t*)b_q_weight.data_ptr(),
+        (const uint32_t*)b_gptq_qzeros.data_ptr(),
+        (const half*)b_gptq_scales.data_ptr(), (half*)c.data_ptr(), c.size(0),
+        c.size(1), a.size(1), b_gptq_qzeros.size(0), use_v2_format);
+    return c;
+  }
+#endif
+
   at::Tensor temp_dq = torch::empty(
       {b_q_weight.size(0) * 32 / bit, b_q_weight.size(1)}, options);
 

--- a/tests/kernels/quantization/test_gptq.py
+++ b/tests/kernels/quantization/test_gptq.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import pytest
 import torch
 
 from tests.kernels.utils import opcheck
@@ -33,3 +34,49 @@ def test_gptq_gemm_opcheck():
     opcheck(
         torch.ops._C.gptq_gemm, (a, weight, zeros, scales, idx, use_exllama, False, bit)
     )
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() != (6, 1),
+    reason="Pascal DP4A kernel requires compute capability 6.1",
+)
+@pytest.mark.parametrize("use_v2_format", [False, True])
+@pytest.mark.parametrize("size_k,group_size,atol", [(256, 64, 0.03), (4096, 128, 0.12)])
+def test_gptq_gemm_pascal_dp4a_numerics(
+    use_v2_format: bool, size_k: int, group_size: int, atol: float
+):
+    torch.manual_seed(0)
+    size_n = 256
+    groups = size_k // group_size
+
+    q_values = torch.randint(0, 16, (size_k, size_n), device="cuda", dtype=torch.int64)
+    shifts = torch.arange(0, 32, 4, device="cuda", dtype=torch.int64)
+    qweight = (
+        (q_values.reshape(size_k // 8, 8, size_n) << shifts[None, :, None])
+        .sum(dim=1)
+        .to(torch.int32)
+    )
+
+    zero_points = torch.randint(
+        1, 16, (groups, size_n), device="cuda", dtype=torch.int64
+    )
+    stored_zeros = zero_points if use_v2_format else zero_points - 1
+    qzeros = (
+        (stored_zeros.reshape(groups, size_n // 8, 8) << shifts[None, None, :])
+        .sum(dim=-1)
+        .to(torch.int32)
+    )
+    scales = (
+        torch.rand((groups, size_n), device="cuda", dtype=torch.float16) * 0.04 + 0.01
+    )
+    a = torch.randn((1, size_k), device="cuda", dtype=torch.float16) * 0.5
+    empty_idx = torch.empty((0,), device="cuda", dtype=torch.int32)
+
+    output = torch.ops._C.gptq_gemm(
+        a, qweight, qzeros, scales, empty_idx, False, use_v2_format, 4
+    )
+    weight = (q_values - zero_points.repeat_interleave(group_size, dim=0)).float()
+    weight *= scales.repeat_interleave(group_size, dim=0).float()
+    reference = a.float() @ weight
+
+    torch.testing.assert_close(output.float(), reference, rtol=0.03, atol=atol)

--- a/vllm/model_executor/layers/quantization/gptq.py
+++ b/vllm/model_executor/layers/quantization/gptq.py
@@ -29,6 +29,7 @@ from vllm.model_executor.parameter import (
     PackedvLLMParameter,
     RowvLLMParameter,
 )
+from vllm.platforms import current_platform
 from vllm.transformers_utils.config import get_safetensors_params_metadata
 from vllm.utils.collection_utils import is_list_of
 
@@ -39,6 +40,8 @@ else:
     QuantizationMethods = str
 
 logger = init_logger(__name__)
+
+PASCAL_DP4A_MAX_ROWS = 8
 
 
 class GPTQConfig(QuantizationConfig):
@@ -94,9 +97,16 @@ class GPTQConfig(QuantizationConfig):
                 "Currently, only 2/3/4/8-bit weight quantization is "
                 f"supported for GPTQ, but got {self.weight_bits} bits."
             )
-        # Somehow gptq_gemm 4-bit is buggy, maybe fix it in the future.
-        # For now, show a warning, since gptq_marlin will be used by default.
-        if self.weight_bits == 4:
+        # Pascal uses a dedicated DP4A kernel for sequential 4-bit weights.
+        # Other gptq_gemm configurations retain the existing warning since
+        # gptq_marlin remains the preferred CUDA path where it is available.
+        pascal_dp4a = (
+            self.weight_bits == 4
+            and not self.desc_act
+            and (self.group_size == -1 or self.group_size % 32 == 0)
+            and current_platform.is_device_capability(61)
+        )
+        if self.weight_bits == 4 and not pascal_dp4a:
             logger.warning_once(
                 "Currently, the 4-bit gptq_gemm kernel for GPTQ is buggy. "
                 "Please switch to gptq_marlin."
@@ -238,6 +248,13 @@ class GPTQLinearMethod(LinearMethodBase):
     def __init__(self, quant_config: GPTQConfig):
         self.quant_config = quant_config
 
+        self.use_pascal_dp4a = (
+            quant_config.weight_bits == 4
+            and not quant_config.desc_act
+            and (quant_config.group_size == -1 or quant_config.group_size % 32 == 0)
+            and current_platform.is_device_capability(61)
+        )
+
         # GPTQ v1 and v2 format deals with zero points differently
         self.use_v2_format = quant_config.checkpoint_format == "gptq_v2"
 
@@ -271,7 +288,17 @@ class GPTQLinearMethod(LinearMethodBase):
             group_size = self.quant_config.group_size
         else:
             group_size = input_size
-        exllama_state = ExllamaState.UNINITIALIZED
+        layer.pascal_dp4a_enabled = (
+            self.use_pascal_dp4a
+            and input_size == input_size_per_partition
+            and input_size_per_partition % 32 == 0
+            and group_size % 32 == 0
+        )
+        exllama_state = (
+            ExllamaState.UNUSED
+            if layer.pascal_dp4a_enabled
+            else ExllamaState.UNINITIALIZED
+        )
         scale_and_zero_size = input_size // group_size
         scale_and_zero_input_dim = None
         if (
@@ -302,7 +329,12 @@ class GPTQLinearMethod(LinearMethodBase):
         g_idx = RowvLLMParameter(
             data=torch.tensor(
                 [
-                    i // self.quant_config.group_size
+                    i
+                    // (
+                        group_size
+                        if layer.pascal_dp4a_enabled
+                        else self.quant_config.group_size
+                    )
                     for i in range(input_size_per_partition)
                 ],
                 dtype=torch.int32,
@@ -361,6 +393,16 @@ class GPTQLinearMethod(LinearMethodBase):
         layer.g_idx = Parameter(layer.g_idx.data, requires_grad=False)
         layer.scales = Parameter(layer.scales.data, requires_grad=False)
 
+        if layer.pascal_dp4a_enabled:
+            # Preserve the sequential g_idx for large-prefill reconstruction.
+            # An empty tensor selects DP4A only for the small-row decode path.
+            layer.register_buffer(
+                "pascal_dp4a_idx",
+                torch.empty((0,), dtype=torch.int, device=layer.g_idx.device),
+                persistent=False,
+            )
+            return
+
         # exllama needs to shuffle the weight after the weight is loaded
         # here we do the shuffle on first forward pass
         if layer.exllama_state == ExllamaState.UNINITIALIZED:
@@ -384,12 +426,17 @@ class GPTQLinearMethod(LinearMethodBase):
 
         # GPTQ v1 and v2 format checkpoints deals with zero points differently,
         # and require different gemm kernels.
+        g_idx = (
+            layer.pascal_dp4a_idx
+            if layer.pascal_dp4a_enabled and reshaped_x.shape[0] <= PASCAL_DP4A_MAX_ROWS
+            else layer.g_idx
+        )
         output = ops.gptq_gemm(
             reshaped_x,
             layer.qweight,
             layer.qzeros,
             layer.scales,
-            layer.g_idx,
+            g_idx,
             layer.exllama_state == ExllamaState.READY,
             self.use_v2_format,
             self.quant_config.weight_bits,


### PR DESCRIPTION
## Summary

- add an `sm_61`-only GPTQ INT4 decode path that quantizes FP16 activations to INT8 in shared memory and multiplies packed 4-bit weights with Pascal DP4A instructions
- add a split-K specialization for wide down projections, plus safe large-prefill and unsupported-shape fallbacks
- relax the GPTQ warning only for eligible sequential 4-bit Pascal layers
- cover GPTQ v1/v2 zero-point formats and both regular/split-K kernels
- document HT's Pascal build and GPTQ features in the README

## Why

Pascal has fast `__dp4a` integer dot products but native FP16 arithmetic is exceptionally slow. The classic GPTQ path reconstructs INT4 weights to FP16 before GEMM, making decode slower than FP16 despite the reduced checkpoint size. This change keeps the hot multiply on DP4A and limits activation quantization error with 32-value blocks.

The route is restricted to compute capability 6.1, 4-bit sequential weights, single-GPU 32-aligned layers, and at most eight rows. Existing reconstruction and ExLlama behavior remains the fallback.

## Benchmarks

Quadro P5200 (`sm_61`), Qwen2.5-1.5B-Instruct, FP16 versus GPTQ-Int4, eager mode, one sequence, 128 generated tokens after warm-up:

| Configuration | Median time | Throughput |
| --- | ---: | ---: |
| FP16 | 3.273 s | 39.1 tok/s |
| GPTQ INT4 DP4A | 2.970 s | 43.1 tok/s |

End-to-end speedup: **1.10×**. This is a measured win, though below the RFC's aspirational 1.5× target.

Representative single-row kernel timings:

| Projection | INT4 | FP16 | Speedup |
| --- | ---: | ---: | ---: |
| `q_proj` (1536×1536) | 0.03772 ms | 0.04390 ms | 1.16× |
| `gate_proj` (1536×8960) | 0.07126 ms | 0.16556 ms | 2.32× |
| `down_proj` (8960×1536) | 0.09537 ms | 0.19253 ms | 2.02× |

Correctness checks through the OpenAI chat endpoint returned `4` for “What is 2 plus 2?” and `Paris` for the capital of France. Direct kernel comparisons against dequantized FP32 references produced cosine similarity from 0.99997 to 0.99999.

## Validation

- `.venv/bin/python -m pytest tests/kernels/quantization/test_gptq.py -v` — 6 passed
- `.venv/bin/cmake --build cmake-build-pascal --target _C -j2` — passed with `TORCH_CUDA_ARCH_LIST=6.1`
- full staged-file pre-commit suite — passed
- end-to-end FP16 and GPTQ servers used port 8010, `--gpu-memory-utilization 0.25`, and were removed after each run

## Duplicate-work check

No open PR in `heiervang-technologies/ht-vllm` or upstream vLLM addresses a Pascal DP4A GPTQ kernel. Upstream PR #38966 concerns automatic GPTQ v1/v2 format detection and is materially different.

Tracks heiervang-technologies/hai-os#136.

AI assistance was used to implement, test, benchmark, and prepare this change. Markus approved publishing this draft and will peer-review it before squash-merging; this PR must not be self-merged.
